### PR TITLE
Update fixedPrices.js

### DIFF
--- a/final-code-with-improvments/ecommerce-front/src/core/fixedPrices.js
+++ b/final-code-with-improvments/ecommerce-front/src/core/fixedPrices.js
@@ -22,11 +22,11 @@ export const prices = [
     {
         _id: 4,
         name: "$30 to $39",
-        array: [20, 29]
+        array: [30, 39]
     },
     {
         _id: 5,
         name: "More than $40",
-        array: [40, 99]
+        array: [40, 999999]
     }
 ];


### PR DESCRIPTION
Typo error price interval 30 39 is by mistake 20 29 (copied from id:3 but not fully edited)
I also extend "more than $40" for super expensive products